### PR TITLE
added prettierrc section to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,14 @@ If you installed prettier as a local dependency, you can add prettier as a scrip
 }
 ```
 
+also add it as a plugin to your [prettierrc](https://prettier.io/docs/en/configuration.html),
+
+```json
+"plugins": [
+  "@prettier/plugin-lua"
+]
+```
+
 and then run it via
 
 ```bash


### PR DESCRIPTION
Prettier could not infer the parser if i didn't add this to the `prettierrc` in my repo.

As i couldn't find any information regarding this i had to do some research and found that this worked.