### PR TITLE
Prettier ignore

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,14 @@ If you installed prettier as a local dependency, you can add prettier as a scrip
 }
 ```
 
+also add it as a plugin to your [prettierrc](https://prettier.io/docs/en/configuration.html),
+
+```json
+"plugins": [
+  "@prettier/plugin-lua"
+]
+```
+
 and then run it via
 
 ```bash

--- a/src/comments.js
+++ b/src/comments.js
@@ -134,6 +134,12 @@ function isBlockComment(comment) {
   return /^\-\-\[=*\[/.test(comment.raw);
 }
 
+function commentsHavePrettierIgnore(comments) {
+  return comments.find(comment =>
+    comment.value.includes("prettier-ignore")
+  )
+}
+
 module.exports = {
   handleComments,
   printDanglingComments,
@@ -144,4 +150,5 @@ module.exports = {
   isLeadingComment,
   isTrailingComment,
   isBlockComment,
+  commentsHavePrettierIgnore,
 };

--- a/src/printer.js
+++ b/src/printer.js
@@ -18,10 +18,16 @@ const {
 const { willBreak } = require("prettier").doc.utils;
 const { makeString, isNextLineEmpty } = require("prettier").util;
 const { isValidIdentifier, isExpression } = require("./util");
-const { printDanglingComments, isDanglingComment } = require("./comments");
+const { commentsHavePrettierIgnore, printDanglingComments, isDanglingComment } = require("./comments");
 
 function printNoParens(path, options, print) {
   const node = path.getValue();
+  
+  // check for prettier-ignore
+  if (node.comments && commentsHavePrettierIgnore(node.comments)) {
+    // return the original text
+    return options.originalText.slice(node.range[0], node.range[1])
+  }
 
   switch (node.type) {
     case "Chunk": {


### PR DESCRIPTION
This is a quick and dirty implementation of ignoring a node that should be ignored based on a comment containing `prettier-ignore`.

I added a function that searches comments for said string in `comments.js` and the logic to just paste the original text in printer.js at the very top of the function.

This should fix #25